### PR TITLE
Update package pipeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "svelte-tiptap",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "svelte-tiptap",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^17.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "devDependencies": {
         "@commitlint/cli": "^17.3.0",
         "@sveltejs/adapter-static": "^1.0.0",
-        "@sveltejs/kit": "^1.0.1",
-        "@sveltejs/package": "^1.0.1",
+        "@sveltejs/kit": "^1.8.3",
+        "@sveltejs/package": "^2.0.0",
         "@testing-library/svelte": "^3.2.2",
         "@tiptap/core": "^2.0.0-beta.209",
         "@tiptap/extension-bubble-menu": "^2.0.0-beta.209",
@@ -44,8 +44,10 @@
         "svelte2tsx": "^0.6.0",
         "tailwindcss": "^3.2.4",
         "ts-jest": "^29.0.3",
+        "ts-patch": "^2.1.0",
         "tslib": "^2.4.1",
         "typescript": "^4.9.4",
+        "typescript-transform-extensions": "^1.0.1",
         "vite": "^4.0.3",
         "vitest": "^0.25.8"
       },
@@ -2040,25 +2042,25 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.1.tgz",
-      "integrity": "sha512-C41aCaDjA7xoUdsrc/lSdU1059UdLPIRE1vEIRRynzpMujNgp82bTMHkDosb6vykH6LrLf3tT2w2/5NYQhKYGQ==",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.8.3.tgz",
+      "integrity": "sha512-32tiLy5PPpt2lquK2p53/5wR+ghAXw0HymIBEezmwmwtzx7Xf36xw3RG3fDYQ9gyzon89T+JRweXgAv/qhhvSQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte": "^2.0.0",
         "@types/cookie": "^0.5.1",
         "cookie": "^0.5.0",
-        "devalue": "^4.2.0",
+        "devalue": "^4.3.0",
         "esm-env": "^1.0.0",
         "kleur": "^4.1.5",
-        "magic-string": "^0.27.0",
+        "magic-string": "^0.29.0",
         "mime": "^3.0.0",
         "sade": "^1.8.1",
         "set-cookie-parser": "^2.5.1",
         "sirv": "^2.0.2",
         "tiny-glob": "^0.2.9",
-        "undici": "5.14.0"
+        "undici": "5.20.0"
       },
       "bin": {
         "svelte-kit": "svelte-kit.js"
@@ -2071,16 +2073,28 @@
         "vite": "^4.0.0"
       }
     },
+    "node_modules/@sveltejs/kit/node_modules/magic-string": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.29.0.tgz",
+      "integrity": "sha512-WcfidHrDjMY+eLjlU+8OvwREqHwpgCeKVBUpQ3OhYYuvfaYCUgcbuBzappNzZvg/v8onU3oQj+BYpkOJe9Iw4Q==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@sveltejs/package": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@sveltejs/package/-/package-1.0.1.tgz",
-      "integrity": "sha512-iYoDz4AEJQUfdKUfBcwtYEGYkf4NMByQL3Sl2ESnu+IXsLNsHvhH0zUDhAmUmAgcrH8fVjiR7FuJeyh+7EQtiw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@sveltejs/package/-/package-2.0.2.tgz",
+      "integrity": "sha512-cCOCcO8yMHnhHyaR51nQtvKZ3o/vSU9UYI1EXLT1j2CKNPMuH1/g6JNwKcNNrtQGwwquudc69ZeYy8D/TDNwEw==",
       "dev": true,
       "dependencies": {
         "chokidar": "^3.5.3",
         "kleur": "^4.1.5",
         "sade": "^1.8.1",
-        "svelte2tsx": "~0.5.20"
+        "svelte2tsx": "~0.6.0"
       },
       "bin": {
         "svelte-package": "svelte-package.js"
@@ -2090,20 +2104,6 @@
       },
       "peerDependencies": {
         "svelte": "^3.44.0"
-      }
-    },
-    "node_modules/@sveltejs/package/node_modules/svelte2tsx": {
-      "version": "0.5.23",
-      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.5.23.tgz",
-      "integrity": "sha512-jYFnugTQRFmUpvLXPQrKzVYcW5ErT+0QCxg027Zx9BuvYefMZFuoBSTDYe7viPEFGrPPiLgT2m7f5n9khE7f7Q==",
-      "dev": true,
-      "dependencies": {
-        "dedent-js": "^1.0.1",
-        "pascal-case": "^3.1.1"
-      },
-      "peerDependencies": {
-        "svelte": "^3.24",
-        "typescript": "^4.1.2"
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
@@ -4473,9 +4473,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-4.2.0.tgz",
-      "integrity": "sha512-mbjoAaCL2qogBKgeFxFPOXAUsZchircF+B/79LD4sHH0+NHfYm8gZpQrskKDn5gENGt35+5OI1GUF7hLVnkPDw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-4.3.0.tgz",
+      "integrity": "sha512-n94yQo4LI3w7erwf84mhRUkUJfhLoCZiLyoOZ/QFsDbcWNZePrLwbQpvZBUG2TNxwV3VjCKPxkiiQA6pe3TrTA==",
       "dev": true
     },
     "node_modules/didyoumean": {
@@ -5691,6 +5691,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "dependencies": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
+    },
+    "node_modules/global-prefix/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
     "node_modules/globals": {
       "version": "13.19.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
@@ -6085,6 +6117,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-arguments": {
@@ -9728,6 +9769,35 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/rechoir/node_modules/resolve": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -10132,6 +10202,23 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/side-channel": {
@@ -11078,6 +11165,84 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
     },
+    "node_modules/ts-patch": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-patch/-/ts-patch-2.1.0.tgz",
+      "integrity": "sha512-+6LbQSGgHUnK+grgk9nvKhesc0/dDNxms0IL1XPZeTfmPFCx/QSuwz9k+9yFe0xYDD7xBlHYK0Zp0qrTCaJcAw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "glob": "^8.0.3",
+        "global-prefix": "^3.0.0",
+        "minimist": "^1.2.6",
+        "resolve": "^1.22.1",
+        "shelljs": "^0.8.5",
+        "strip-ansi": "^6.0.1"
+      },
+      "bin": {
+        "ts-patch": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.0.0"
+      }
+    },
+    "node_modules/ts-patch/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/ts-patch/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ts-patch/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-patch/node_modules/resolve": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "dev": true,
+      "dependencies": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
@@ -11169,6 +11334,12 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/typescript-transform-extensions": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/typescript-transform-extensions/-/typescript-transform-extensions-1.0.1.tgz",
+      "integrity": "sha512-kV+h7R2Uenc6Jb/JDkKh8owJuW/LcaUg0cJQMTeJzvFdSiPOpfJhFkjEKAnTcRKYnHWSW+QOUcu5RnBFR8W5lQ==",
+      "dev": true
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -11185,9 +11356,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
-      "integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
       "dev": true,
       "dependencies": {
         "busboy": "^1.6.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "npm run check && vitest run",
     "e2e": "cypress open --e2e",
     "lint": "eslint . --ext .js,.ts,.svelte --ignore-path .gitignore",
-    "prepare": "is-ci || husky install",
+    "prepare": "ts-patch install -s && is-ci || husky install",
     "prepublishOnly": "is-ci || npm run build"
   },
   "peerDependencies": {
@@ -39,8 +39,8 @@
   "devDependencies": {
     "@commitlint/cli": "^17.3.0",
     "@sveltejs/adapter-static": "^1.0.0",
-    "@sveltejs/kit": "^1.0.1",
-    "@sveltejs/package": "^1.0.1",
+    "@sveltejs/kit": "^1.8.3",
+    "@sveltejs/package": "^2.0.0",
     "@testing-library/svelte": "^3.2.2",
     "@tiptap/core": "^2.0.0-beta.209",
     "@tiptap/extension-bubble-menu": "^2.0.0-beta.209",
@@ -72,9 +72,22 @@
     "svelte2tsx": "^0.6.0",
     "tailwindcss": "^3.2.4",
     "ts-jest": "^29.0.3",
+    "ts-patch": "^2.1.0",
     "tslib": "^2.4.1",
     "typescript": "^4.9.4",
+    "typescript-transform-extensions": "^1.0.1",
     "vite": "^4.0.3",
     "vitest": "^0.25.8"
-  }
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "svelte": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "svelte": "./dist/index.js",
+  "types": "./dist/index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "e2e": "cypress open --e2e",
     "lint": "eslint . --ext .js,.ts,.svelte --ignore-path .gitignore",
     "prepare": "ts-patch install -s && is-ci || husky install",
-    "prepublishOnly": "is-ci || npm run build"
+    "prepublishOnly": "is-ci || npm run build",
+    "publish:npm": "npm publish --access public"
   },
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.207",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "svelte-tiptap",
   "description": "Svelte components for tiptap v2",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": "sibiraj-s",
   "license": "MIT",
   "repository": "https://github.com/sibiraj-s/svelte-tiptap.git",
@@ -27,7 +27,7 @@
     "lint": "eslint . --ext .js,.ts,.svelte --ignore-path .gitignore",
     "prepare": "ts-patch install -s && is-ci || husky install",
     "prepublishOnly": "is-ci || npm run build",
-    "publish:npm": "npm publish --access public"
+    "publish:npm": "npm publish"
   },
   "peerDependencies": {
     "@tiptap/core": "^2.0.0-beta.207",
@@ -83,7 +83,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "svelte": "./dist/index.js"
+      "svelte": "./dist/index.js",
+      "import": "./dist/index.js"
     }
   },
   "files": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,13 @@
     "strict": true,
     "noImplicitAny": true,
     "noImplicitOverride": true,
-    "target": "ES2021" // ES2022 or later breaks SvelteNodeViewRenderer
+    "target": "ES2021", // ES2022 or later breaks SvelteNodeViewRenderer
+    "plugins": [
+      {
+        "transform": "typescript-transform-extensions", // workaround for https://github.com/sveltejs/kit/issues/2040
+        "extensions": { ".ts": ".js" }
+      }
+    ]
   }
   // Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
   //


### PR DESCRIPTION
This PR address #16 to ensure `.js` extensions are used when packaging for npm. File extensions are required for Node.js compatibility across the board, and currently when svelte-tiptap is packaged the typescript (lack of) extensions don't get converted to `.js` extensions.

This PR fixes that.

The workaround for https://github.com/sveltejs/kit/issues/2040 with `ts-patch` and `typescript-transform-extensions` and  is used until kit publishes an official fix.

The latest `@sveltejs/package` is used where it is saved to `dist` folder, so there is an `publish:npm` script command also added to the `package.json` so it's clear that the root folder should be published (instead of the legacy `./package` folder).